### PR TITLE
add about and event page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,33 @@
+import { Box, Container } from '@mantine/core';
+
 export default function About() {
   return (
-    <h2>Working in progress</h2>
+    <Container size={'lg'}>
+      <Box>
+        <h2>Background</h2>
+        <p>GoLive Musician’s League is a non-profit organization dedicated to promoting live music culture, supporting original music, nurturing emerging bands, and actively collaborating with local businesses. Our mission is to create more stage opportunities for music enthusiasts while helping our partners attract audiences—achieving true mutual benefit.</p>
+        <p>We began as an organically formed music community called “Weekend Jam,” initiated in late 2023 by a group of friends who share a passion for singing, instrumental performance, and the thrill of being on stage. Initially hosted as restaurant gigs, our events featured mostly amateur musicians with full-time jobs, often performing in a spontaneous, jam-style format. The jam style is perfect for attracting musicians to participate. Periodically, we also organize rehearsals and host high-quality themed concerts.</p>
+        <p>As our influence grew, Weekend Jam evolved into a key platform for grassroots music culture in Silicon Valley. Regular performances are held every Saturday evening at several restaurants and bars in the bay area of North California, attracting musicians, vocalists, and music lovers to gather and share the joy and freedom of live music.</p>
+        <h2>Vision and Future Development</h2>
+        <p>As Weekend Jam continued to grow, we recognized the need for a more structured organization and stronger resource support to sustain and advance the local music ecosystem. Thus, we established GoLive Musician’s League to provide a solid foundation for the growth and spread of music culture in Silicon Valley and beyond through improved operations and outreach.</p>
+        <p>Our goals include:</p>
+        <ul>
+          <li><b>Promote live music performances:</b> Create more opportunities for musicians to showcase their talent on stage</li>
+          <li><b>Support original music:</b> Encourage independent artists and provide platforms for sharing and promoting their work</li>
+          <li><b>Foster emerging bands:</b> Offer more performance and collaboration opportunities for grassroots bands</li>
+          <li><b>Co-host major music events:</b> Partner with businesses and venues to organize concerts and music festivals</li>
+          <li><b>Establish win-win collaboration models:</b> Help venues attract customers while providing musicians with a stable platform for live performances</li>
+        </ul>
+        <h2>Outreach and Sponsorship Invitation</h2>
+        <p>GoLive Musician’s League has officially applied for 501(c)(3) nonprofit status, allowing us to legally receive sponsorships and donations from individuals and businesses. We sincerely invite you to join us in cultivating and expanding the local music scene.</p>
+        <p>For individuals or organizations that support us, we offer various forms of appreciation, including but not limited to:</p>
+        <ul>
+          <li><b>Music lessons of equivalent value,</b> helping supporters enhance their musical skills</li>
+          <li><b>Customized live performances</b> for private parties or special events</li>
+          <li><b>Brand exposure for sponsors</b> through performances and our community platforms</li>
+        </ul>
+        <p>If you’re interested in supporting our cause or learning more about partnership and sponsorship opportunities, we’d love to hear from you. Your support not only brings a stage to music lovers—it helps ignite the cultural spirit of our community.</p>
+      </Box>
+    </Container>
   );
 }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,5 +1,31 @@
+import { Box, Container } from '@mantine/core';
+
 export default async function Events() {
   return (
-    <h2>Working in progress</h2>
+    <Container size={'lg'}>
+      <Box>
+        <h2>Weekend Jam Year-End Party | Proudly Presents GoLive</h2>
+        <h3>About GoLive Musician’s League</h3>
+        <p><b>GoLive Musician’s League</b> originated from a spontaneous music community called <b>“Weekend Jam.”</b> Founded in late 2023 by a group of friends who love singing, playing instruments, and sharing the joy of performing, GoLive is a registered <b>501(c)(3) nonprofit organization</b> in the United States.</p>
+        <p>Its mission is to <b>promote live music culture, support original music, empower emerging bands,</b> and <b>create more opportunities for music lovers to perform on stage.</b></p>
+        <p>Through events like <b>Weekend Jam</b>, we provide open stages for musicians, encourage artistic exchange, and bring together people in the community who share a passion for music—to connect, share, and create.</p>
+
+        <h3>Weekend Jam Year-End Party</h3>
+        <p>As its influence has grown, <b>Weekend Jam</b> has become a vital platform for grassroots music culture in Silicon Valley. Collaborating with multiple restaurants and bars across the Bay Area, we host live sessions every Saturday night that attract numerous musicians, singers, and music enthusiasts who come together to celebrate the freedom and passion of music.</p>
+        <p>To thank all the performers and fans who have participated in <b>Weekend Jam</b>, we warmly invite you to join our Year-End Music Party!</p>
+        <br/>
+        <p>📅 Date: Saturday, November 22, 2025, at 6:00 PM</p>
+        <p>📍 Venue: HalalStreet Hotpot Restaurant</p>
+        <p>5605 Mowry School Rd, Newark, CA 94560</p>
+        <p>🎶 Live Performances | 🍷 Food & Drinks | 🎤 Open Mic</p>
+        <p>👉 Tickets: $50 per person | Children under 12: $20</p>
+        <br/>
+        <p>GoLive’s events are made possible entirely through <b>volunteer efforts and donations</b>. All donations are <b>tax-deductible</b>, and you can donate through your company’s website on <a href={'https://benevity.com'}>benevity.com</a> by searching for <b>“GoLive
+          Musician’s League.”</b></p>
+        <br/>
+        <p>🎁 Donors who contribute <b>$400 or more this year (including company match)</b> will receive <b>free
+          admission</b> and a <b>special acknowledgment</b> at the event.</p>
+      </Box>
+    </Container>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,9 @@ export default function RootLayout({
           <NavHeader>
             <NavThemeToggle />
           </NavHeader>
-          {children}
+          <main>
+            {children}
+          </main>
           <Footer/>
         </MantineProvider>
       </body>


### PR DESCRIPTION
## In this PR
- Add "about" page w/ content from Notion
- Update "event" page feat. the upcoming event

### a11y
- Wrap main content w/ `<main>` tag